### PR TITLE
`border` and `borderColor` functions

### DIFF
--- a/examples/border.d
+++ b/examples/border.d
@@ -13,10 +13,9 @@ void main()
     {
         fill(0, 0, 255);
         noStroke;
-        point(10, 10, 1);
 
-        fill(0, 255, 0);
-        pixel(15, 10);
-        saveAs("output/dot.png", resolution: 72);
+        borderColor("#eecc88");
+        border(5, margin: 20, radius: 7);
+        saveAs("output/border.png");
     }
 }

--- a/source/chitra/context.d
+++ b/source/chitra/context.d
@@ -26,18 +26,19 @@ class Context
     Element[] elements;
     cairo_surface_t* defaultSurface;
     cairo_t* defaultCairoCtx;
-    private int width_;
-    private int height_;
+    private double width_;
+    private double height_;
     int resolution_ = 0;
     ShapeProperties shapeProps;
     TextProperties textProps;
+    BorderProperties borderProps;
 
-    int width()
+    double width()
     {
         return width_;
     }
 
-    int height()
+    double height()
     {
         return height_;
     }
@@ -61,12 +62,12 @@ class Context
         return cast(T)((value / cast(double)resolution_) * baseResolution);
     }
 
-    this(int width = defaultWidth, int height = 0)
+    this(double width = defaultWidth, double height = 0)
     {
         this.width_ = width;
         this.height_ = height == 0 ? width : height;
         this.defaultSurface = cairo_image_surface_create(CAIRO_FORMAT_ARGB32,
-            correctedSize(this.width_), correctedSize(this.height_));
+            correctedSize(this.width_).to!int, correctedSize(this.height_).to!int);
         this.defaultCairoCtx = cairo_create(this.defaultSurface);
 
         // Scale the default stroke width based on the resolution
@@ -101,8 +102,8 @@ class Context
         {
             throw new Exception("invalid paper");
         }
-        auto w = (*size)[0].mm.to!int;
-        auto h = (*size)[1].mm.to!int;
+        auto w = (*size)[0].mm;
+        auto h = (*size)[1].mm;
 
         if (orientation == landscapeMode)
             swap(w, h);
@@ -159,7 +160,7 @@ class Context
     {
         elements = [];
         defaultSurface = cairo_image_surface_create(CAIRO_FORMAT_ARGB32,
-                                                    correctedSize(this.width_), correctedSize(this.height_));
+                                                    correctedSize(this.width_).to!int, correctedSize(this.height_).to!int);
         defaultCairoCtx = cairo_create(this.defaultSurface);
         shapeProps = ShapeProperties.init;
         textProps = TextProperties.init;

--- a/source/chitra/elements/rect.d
+++ b/source/chitra/elements/rect.d
@@ -138,10 +138,24 @@ mixin template rectFunctions()
         strokeWidth(prevStrokeWidth);
     }
 
-    void border(int thickness = 2, Nullable!RGBA color = color(0),
-                float m = 0.0, float mt = -1.0, float mr = -1.0, float mb = -1.0, float ml = -1.0,
-                float r = 0.0, float rtl = -1.0, float rtr = -1.0, float rbr = -1.0, float rbl = -1.0)
+    /**
+       Draw a border.
+
+       ---
+       ctx.border(5);
+       ctx.border(5, margin: 10, radius: 7, color: RGBA.parse("blue"));
+       ---
+     */
+    void border(int thickness = 2, Nullable!RGBA color = Nullable!RGBA.init,
+                float margin = 0.0, float marginTop = -1.0, float marginRight = -1.0,
+                float marginBottom = -1.0, float marginLeft = -1.0,
+                float radius = 0.0, float radiusTopLeft = -1.0, float radiusTopRight = -1.0,
+                float radiusBottomRight = -1.0, float radiusBottomLeft = -1.0)
     {
+
+        if (color.isNull)
+            color = this.borderProps.fill;
+
         auto prevFillColor = this.shapeProps.fill;
         auto prevStrokeColor = this.shapeProps.stroke;
         auto prevStrokeWidth = this.shapeProps.strokeWidth;
@@ -150,14 +164,23 @@ mixin template rectFunctions()
         this.shapeProps.stroke = color.get;
         strokeWidth(thickness);
 
-        if (mt < 0) mt = m;
-        if (mr < 0) mr = m;
-        if (mb < 0) mb = m;
-        if (ml < 0) ml = m;
+        if (marginTop < 0) marginTop = margin;
+        if (marginRight < 0) marginRight = margin;
+        if (marginBottom < 0) marginBottom = margin;
+        if (marginLeft < 0) marginLeft = margin;
 
         auto halfThickness = thickness / 2.0;
-        rect(ml + halfThickness, mt + halfThickness, this.width - ml - mr - thickness, this.height - mt - mb - thickness,
-             r: r, rtl: rtl, rtr: rtr, rbl: rbl, rbr: rbr);
+        rect(
+            marginLeft + halfThickness,
+            marginTop + halfThickness,
+            this.width - marginLeft - marginRight - thickness,
+            this.height - marginTop - marginBottom - thickness,
+            r: radius,
+            rtl: radiusTopLeft,
+            rtr: radiusTopRight,
+            rbl: radiusBottomLeft,
+            rbr: radiusBottomRight
+        );
 
         this.shapeProps.fill = prevFillColor;
         this.shapeProps.stroke = prevStrokeColor;

--- a/source/chitra/package.d
+++ b/source/chitra/package.d
@@ -7,11 +7,11 @@ public
 {
     import chitra.helpers;
     import chitra.elements.formatted_strings;
+    import chitra.rgba;
 }
 import chitra.context;
 import chitra.properties;
 import chitra.elements;
-import chitra.rgba;
 
 class Chitra : Context
 {
@@ -47,7 +47,7 @@ class Chitra : Context
        auto ctx = new Chitra(1600, 900);
        ---
      */
-    this(int width = defaultWidth, int height = 0)
+    this(double width = defaultWidth, double height = 0)
     {
         super(width, height);
     }

--- a/source/chitra/properties.d
+++ b/source/chitra/properties.d
@@ -20,6 +20,11 @@ struct ShapeProperties
     //   line_join = LibCairo::LineJoinT::Miter
 }
 
+struct BorderProperties
+{
+    RGBA fill = RGBA(0);
+}
+
 mixin template propertiesFunctions()
 {
     void fill(int r, int g, int b, float a = 1.0)
@@ -178,5 +183,20 @@ mixin template propertiesFunctions()
     void textFeatures(string value)
     {
         textProps.features = value;
+    }
+
+    void borderColor(int r, int g, int b, float a = 1.0)
+    {
+        borderProps.fill = RGBA(r, g, b, a);
+    }
+
+    void borderColor(int gray, float a = 1.0)
+    {
+        borderProps.fill = RGBA(gray, gray, gray, a);
+    }
+
+    void borderColor(string hexValue)
+    {
+        borderProps.fill = RGBA.parse(hexValue).get;
     }
 }

--- a/source/chitra/surfaces.d
+++ b/source/chitra/surfaces.d
@@ -1,20 +1,21 @@
 module chitra.surfaces;
 
+import std.conv : to;
 import std.string;
 
 import chitra.pangocairo;
 
-cairo_surface_t* createPdfSurface(string outputFile, int width, int height)
+cairo_surface_t* createPdfSurface(string outputFile, double width, double height)
 {
     return cairo_pdf_surface_create(outputFile.toStringz, width, height);
 }
 
-cairo_surface_t* createPngSurface(string outputFile, int width, int height)
+cairo_surface_t* createPngSurface(string outputFile, double width, double height)
 {
-    return cairo_image_surface_create(CAIRO_FORMAT_ARGB32, width, height);
+    return cairo_image_surface_create(CAIRO_FORMAT_ARGB32, width.to!int, height.to!int);
 }
 
-cairo_surface_t* createSvgSurface(string outputFile, int width, int height)
+cairo_surface_t* createSvgSurface(string outputFile, double width, double height)
 {
     return cairo_svg_surface_create(outputFile.toStringz, width, height);
 }


### PR DESCRIPTION
`border` creates the border for given page. It also supports creating the border with rounded corner and margin.

Examples:

```
border(5);
border(5, margin: 10, radius: 7);
```

Also supports adjusting a specific margin or radius: `marginTop`, `marginBottom`, `marginLeft`, `marginRight`, `radiusTopLeft`, `radiusTopRight`, `radiusBottomLeft` and `radiusBottomRight`.

Border color can be customized using `borderColor` or `color` argument.

```
border(5, color: RGBA.parse("blue"));

// Same as above
borderColor("blue");
border(5);
```