### PR TITLE
Color Scale support (`0 - 1.0` or `0 - 255`) added

### DIFF
--- a/examples/color_scale.d
+++ b/examples/color_scale.d
@@ -1,0 +1,44 @@
+/+ dub.sdl:
+ dependency "chitra" path="../"
+ +/
+
+import std.stdio;
+import chitra;
+
+void main()
+{
+    auto ctx = new Chitra(2000, 700);
+
+    with (ctx)
+    {
+        auto w1 = width / 400.0;
+        auto w2 = width / 256.0;
+
+        auto x = 0.0;
+        auto col = 0.0;
+        noStroke();
+
+        colorScale(1);
+        foreach(i; 0 .. 401)
+        {
+            fill(0, 0, col);
+            rect(x, 0, w1, 300);
+            x += w1;
+            col += 0.0025;
+        }
+
+        colorScale(255);
+        x = 0.0;
+        col = 0;
+
+        foreach(i; 0 .. 256)
+        {
+            fill(0, 0, col);
+            rect(x, 400, w2, 300);
+            x += w2;
+            col += 1;
+        }
+
+        saveAs("output/color_scale.png");
+    }
+}

--- a/examples/colors.d
+++ b/examples/colors.d
@@ -1,0 +1,53 @@
+/+ dub.sdl:
+ dependency "chitra" path="../"
+ +/
+
+import std.stdio;
+import chitra;
+
+void main()
+{
+    auto ctx = new Chitra(270);
+
+    with (ctx)
+    {
+
+        // Example 1: Color and Alpha using 0-255 scale
+        colorScale(255);
+        fill(94, 103, 175, 127);
+        stroke(0, 0, 255, 127);
+        rect(10, 10, 50);
+
+        // Example 2: Color using 0-255 scale and Alpha using 0-1.0 scale
+        colorScale(255, 1);
+        fill(94, 103, 175, 0.5);
+        stroke(0, 0, 255, 0.5);
+        rect(60, 60, 50);
+
+        // Example 3: Color and Alpha using 0-1.0 scale
+        colorScale(1);
+        fill(0.368, 0.403, 0.686, 0.5);
+        stroke(0, 0, 1, 0.5);
+        rect(110, 110, 50);
+
+        // Example 4: 0-1.0 scale with color names and using
+        // fillOpacity and strokeOpacity functions
+        colorScale(1);
+        fill("#5e67af");
+        stroke("blue");
+        fillOpacity(0.5);
+        strokeOpacity(0.5);
+        rect(160, 160, 50);
+
+        // Example 5: 0-255 scale with color names and using
+        // fillOpacity and strokeOpacity functions
+        colorScale(255);
+        fill("#5e67af");
+        stroke("blue");
+        fillOpacity(127);
+        strokeOpacity(127);
+        rect(210, 210, 50);
+
+        saveAs("output/colors.png");
+    }
+}

--- a/source/chitra/context.d
+++ b/source/chitra/context.d
@@ -32,6 +32,8 @@ class Context
     ShapeProperties shapeProps;
     TextProperties textProps;
     BorderProperties borderProps;
+    float colorScaleMax = 255.0;
+    float colorScaleAlphaMax = 1.0;
 
     double width()
     {

--- a/source/chitra/elements/core.d
+++ b/source/chitra/elements/core.d
@@ -9,8 +9,8 @@ void drawShapeProperties(Context chitraCtx, cairo_t* cairoCtx, ShapeProperties s
     if (shapeProps.noFill)
         cairo_set_source_rgba(cairoCtx, 0, 0, 0, 0);
     else
-        cairo_set_source_rgba(cairoCtx, shapeProps.fill.r100,
-                              shapeProps.fill.g100, shapeProps.fill.b100, shapeProps.fill.a);
+        cairo_set_source_rgba(cairoCtx, shapeProps.fill.r,
+                              shapeProps.fill.g, shapeProps.fill.b, shapeProps.fill.a);
 
     if (shapeProps.strokeWidth > 0 && !shapeProps.noStroke)
     {
@@ -24,8 +24,8 @@ void drawShapeProperties(Context chitraCtx, cairo_t* cairoCtx, ShapeProperties s
         // end
         // LibCairo.cairo_set_line_cap(cairo_ctx, @line_cap)
         // LibCairo.cairo_set_line_join(cairo_ctx, @line_join)
-        cairo_set_source_rgba(cairoCtx, shapeProps.stroke.r100,
-                              shapeProps.stroke.g100, shapeProps.stroke.b100, shapeProps.stroke.a);
+        cairo_set_source_rgba(cairoCtx, shapeProps.stroke.r,
+                              shapeProps.stroke.g, shapeProps.stroke.b, shapeProps.stroke.a);
         cairo_stroke(cairoCtx);
     }
     else

--- a/source/chitra/properties.d
+++ b/source/chitra/properties.d
@@ -27,14 +27,18 @@ struct BorderProperties
 
 mixin template propertiesFunctions()
 {
-    void fill(int r, int g, int b, float a = 1.0)
+    void fill(float r, float g, float b, float a = -1.0)
     {
         shapeProps.noFill = false;
-        shapeProps.fill = RGBA(r, g, b, a);
+        a = a == -1 ? colorScaleAlphaMax : a / colorScaleAlphaMax;
+        shapeProps.fill = RGBA(r / colorScaleMax, g / colorScaleMax, b / colorScaleMax, a);
+        import std.stdio;
     }
 
-    void fill(int gray, float a = 1.0)
+    void fill(float gray, float a = -1.0)
     {
+        gray = gray / colorScaleMax;
+        a = a == -1 ? colorScaleAlphaMax : a / colorScaleAlphaMax;
         shapeProps.noFill = false;
         shapeProps.fill = RGBA(gray, gray, gray, a);
     }
@@ -46,19 +50,22 @@ mixin template propertiesFunctions()
         shapeProps.fill = RGBA.parse(hexValue).get;
     }
 
-    void fillOpacity(float a = 1.0)
+    void fillOpacity(float a)
     {
-        shapeProps.fill = RGBA(shapeProps.fill.r, shapeProps.fill.g, shapeProps.fill.b, a);
+        shapeProps.fill = RGBA(shapeProps.fill.r, shapeProps.fill.g, shapeProps.fill.b, a / colorScaleAlphaMax);
     }
 
-    void stroke(int r, int g, int b, float a = 1.0)
+    void stroke(float r, float g, float b, float a = -1.0)
     {
         shapeProps.noStroke = false;
-        shapeProps.stroke = RGBA(r, g, b, a);
+        a = a == -1 ? colorScaleAlphaMax : a / colorScaleAlphaMax;
+        shapeProps.stroke = RGBA(r / colorScaleMax, g / colorScaleMax, b / colorScaleMax, a);
     }
 
-    void stroke(int gray, float a = 1.0)
+    void stroke(float gray, float a = 1.0)
     {
+        gray = gray / colorScaleMax;
+        a = a == -1 ? colorScaleAlphaMax : a / colorScaleAlphaMax;
         shapeProps.noStroke = false;
         shapeProps.stroke = RGBA(gray, gray, gray, a);
     }
@@ -70,9 +77,9 @@ mixin template propertiesFunctions()
         shapeProps.stroke = RGBA.parse(hexValue).get;
     }
 
-    void strokeOpacity(float a = 1.0)
+    void strokeOpacity(float a)
     {
-        shapeProps.stroke = RGBA(shapeProps.stroke.r, shapeProps.stroke.g, shapeProps.stroke.b, a);
+        shapeProps.stroke = RGBA(shapeProps.stroke.r, shapeProps.stroke.g, shapeProps.stroke.b, a / colorScaleAlphaMax);
     }
 
     void noStroke()
@@ -92,13 +99,16 @@ mixin template propertiesFunctions()
         shapeProps.noFill = true;
     }
 
-    void textColor(int r, int g, int b, float a = 1.0)
+    void textColor(float r, float g, float b, float a = -1.0)
     {
-        textProps.color = RGBA(r, g, b, a);
+        a = a == -1 ? colorScaleAlphaMax : a / colorScaleAlphaMax;
+        textProps.color = RGBA(r / colorScaleMax, g / colorScaleMax, b / colorScaleMax, a);
     }
 
-    void textColor(int gray, float a = 1.0)
+    void textColor(float gray, float a = 1.0)
     {
+        gray = gray / colorScaleMax;
+        a = a == -1 ? colorScaleAlphaMax : a / colorScaleAlphaMax;
         textProps.color = RGBA(gray, gray, gray, a);
     }
 
@@ -108,20 +118,23 @@ mixin template propertiesFunctions()
         textProps.color = RGBA.parse(hexValue).get;
     }
 
-    void textOpacity(float a = 1.0)
+    void textOpacity(float a)
     {
         auto c = textProps.color;
         if (!c.isNull)
-            textProps.color = RGBA(c.get.r, c.get.g, c.get.b, a);
+            textProps.color = RGBA(c.get.r, c.get.g, c.get.b, a / colorScaleAlphaMax);
     }
 
-    void textBgColor(int r, int g, int b, float a = 1.0)
+    void textBgColor(float r, float g, float b, float a = -1.0)
     {
-        textProps.background = RGBA(r, g, b, a);
+        a = a == -1 ? colorScaleAlphaMax : a / colorScaleAlphaMax;
+        textProps.background = RGBA(r / colorScaleMax, g / colorScaleMax, b / colorScaleMax, a);
     }
 
-    void textBgColor(int gray, float a = 1.0)
+    void textBgColor(float gray, float a = -1.0)
     {
+        gray = gray / colorScaleMax;
+        a = a == -1 ? colorScaleAlphaMax : a / colorScaleAlphaMax;
         textProps.background = RGBA(gray, gray, gray, a);
     }
 
@@ -131,11 +144,11 @@ mixin template propertiesFunctions()
         textProps.background = RGBA.parse(hexValue).get;
     }
 
-    void textBgOpacity(float a = 1.0)
+    void textBgOpacity(float a)
     {
         auto c = textProps.background;
         if (!c.isNull)
-            textProps.background = RGBA(c.get.r, c.get.g, c.get.b, a);
+            textProps.background = RGBA(c.get.r, c.get.g, c.get.b, a / colorScaleAlphaMax);
     }
 
     void textSize(float size)
@@ -185,18 +198,42 @@ mixin template propertiesFunctions()
         textProps.features = value;
     }
 
-    void borderColor(int r, int g, int b, float a = 1.0)
+    void borderColor(float r, float g, float b, float a = -1.0)
     {
-        borderProps.fill = RGBA(r, g, b, a);
+        a = a == -1 ? colorScaleAlphaMax : a / colorScaleAlphaMax;
+        borderProps.fill = RGBA(r / colorScaleMax, g / colorScaleMax, b / colorScaleMax, a);
     }
 
-    void borderColor(int gray, float a = 1.0)
+    void borderColor(float gray, float a = -1.0)
     {
+        gray = gray / colorScaleMax;
+        a = a == -1 ? colorScaleAlphaMax : a / colorScaleAlphaMax;
         borderProps.fill = RGBA(gray, gray, gray, a);
     }
 
     void borderColor(string hexValue)
     {
         borderProps.fill = RGBA.parse(hexValue).get;
+    }
+
+    /**
+       Switch between color Scales (Default is 0-255)
+
+       ---
+       ctx.colorScale(1); // 0-1 Scale
+       ctx.colorScale(255); // 0-255 Scale
+       ---
+
+       To use 0-255 scale for RGB and 0-1 for alpha
+
+       ---
+       ctx.colorScale(255, 1);
+       ctx.fill(186, 239, 60, 0.5);
+       ---
+     */
+    void colorScale(int max = 255, int maxA = 0)
+    {
+        colorScaleMax = max;
+        colorScaleAlphaMax = maxA == 0 ? max : maxA;
     }
 }

--- a/source/chitra/rgba/package.d
+++ b/source/chitra/rgba/package.d
@@ -6,20 +6,26 @@ import std.conv : to;
 
 import chitra.rgba.names;
 
+
+int toScale255(float value)
+{
+    return (value * 255).to!int;
+}
+
 struct RGBA
 {
-    int r;
-    int g;
-    int b;
+    float r;
+    float g;
+    float b;
     float a = 1.0;
 
-    static Nullable!RGBA parse(int r, int g, int b, float a = 1.0)
+    static Nullable!RGBA parse(float r, float g, float b, float a = 1.0)
     {
         // TODO: Handle invalid values
         return RGBA(r, g, b, a).nullable;
     }
 
-    static Nullable!RGBA parse(int gray, float a = 1.0)
+    static Nullable!RGBA parse(float gray, float a = 1.0)
     {
         // TODO: Handle invalid values
         return RGBA(gray, gray, gray, a).nullable;
@@ -32,9 +38,9 @@ struct RGBA
         {
             auto h = name.strip("#");
             RGBA c;
-            c.r = h[0 .. 2].to!int(16);
-            c.g = h[2 .. 4].to!int(16);
-            c.b = h[4 .. 6].to!int(16);
+            c.r = h[0 .. 2].to!int(16)/255.0;
+            c.g = h[2 .. 4].to!int(16)/255.0;
+            c.b = h[4 .. 6].to!int(16)/255.0;
             
             c.a = h.length == 8 ? h[6 .. 8].to!int(16)/255.0 : a;
             color = c;
@@ -45,7 +51,7 @@ struct RGBA
             if (value !is null)
             {
                 auto rgb = *value;
-                color = RGBA(rgb[0], rgb[1], rgb[2], a);
+                color = RGBA(rgb[0] / 255.0, rgb[1] / 255.0, rgb[2] / 255.0, a);
             }
         }
 
@@ -63,28 +69,13 @@ struct RGBA
 
     string hexString()
     {
-        auto alpha = a == 1.0 ? "" : hex_((a * 255).to!int);
-        return "#" ~ hex_(r) ~ hex_(g) ~ hex_(b) ~ alpha;
-    }
-
-    float r100()
-    {
-        return r / 255.0;
-    }
-
-    float g100()
-    {
-        return g / 255.0;
-    }
-
-    float b100()
-    {
-        return b / 255.0;
+        auto alpha = a == 1.0 ? "" : hex_(toScale255(a));
+        return "#" ~ hex_(toScale255(r)) ~ hex_(toScale255(g)) ~ hex_(toScale255(b)) ~ alpha;
     }
 
     string name()
     {
-        auto rgbColor = RGB(r, g, b);
+        auto rgbColor = RGB(toScale255(r), toScale255(g), toScale255(b));
         foreach (color; colorNames.byKeyValue)
         {
             if (color.value == rgbColor)
@@ -100,17 +91,17 @@ unittest
 {
     auto color = RGBA.parse("red");
     assert(!color.isNull);
-    assert(color.get.r == 255);
+    assert(color.get.r == 1);
     assert(color.get.g == 0);
     assert(color.get.b == 0);
     assert(color.get.a == 1.0);
 
     auto color2 = RGBA.parse("#dddddd");
     assert(!color2.isNull);
-    assert(color2.get.r == 221);
-    assert(color2.get.g == 221);
-    assert(color2.get.b == 221);
+    assert(toScale255(color2.get.r) == 221);
+    assert(toScale255(color2.get.g) == 221);
+    assert(toScale255(color2.get.b) == 221);
     assert(color2.get.a == 1.0);
 
-    assert(RGBA.parse(221, 221, 221).get.hexString == "#DDDDDDFF");
+    assert(RGBA.parse(221/255.0, 221/255.0, 221/255.0).get.hexString == "#DDDDDD");
 }


### PR DESCRIPTION
Added a new feature to customize the color inputs. Some prefer `0-255` color scale and some prefer floating values from `0-1.0`. For example, Specifying mid value as 50% (0.5) is easy compared to finding 50% or 75% of 255. Chitra now supports selecting the color scale as needed. Default color scale is `0-255` for R, G and B values and `0-1.0` for Alpha.

Examples:

```d
colorScale(255);
fill(0, 0, 255, 127);

colorScale(255, maxA: 1); // Default
fill(0, 0, 255, 0.5);

colorScale(1);
fill(0, 0, 1, 0.5);
```