### PR TITLE
Fix the Translate example

### DIFF
--- a/examples/translate.d
+++ b/examples/translate.d
@@ -3,6 +3,8 @@
  +/
 
 import std.stdio;
+import std.format;
+
 import chitra;
 
 void main()
@@ -12,24 +14,28 @@ void main()
     with (ctx)
     {
         // Translate
-        void bar(double percentage)
+        void bar(string label, double percentage)
         {
-            writeln(percentage, width);
+            noStroke;
+            textColor(0);
+            textFont("Inter", 10);
+            text(label, 0, 0);
+
             if (percentage > 50)
                 fill(0, 255, 0);
             else
                 fill(255, 0, 0);
 
-            rect(0, 0, width*percentage/100, 20);
+            rect(0, 20, width * percentage / 100, 20);
         }
 
         double[] values = [93, 70, 41, 56, 77, 21, 87];
         foreach(i, p; values)
         {
-            writeln(i*50);
-            translate(0, i*50);
-            bar(p);
-            translate(0, -i*50);
+            double translateY = i * 50;
+            translate(0, translateY);
+            bar(format("Subject %d", i), p);
+            translate(0, -translateY);
         }
 
         saveAs("output/translate_bar.png");


### PR DESCRIPTION
ulong was passed to translate function and negative value ignored while converting to double.

This was causing unexpected behaviour when the translated values are reveresed. For example, `i` was declared as `ulong`

```
translate(0, i * 50);
// draw something(...);
translate(0, -i * 50);
```