### PR TITLE
Set the default color of text to Black

### DIFF
--- a/examples/text.d
+++ b/examples/text.d
@@ -1,0 +1,24 @@
+/+ dub.sdl:
+ dependency "chitra" path="../"
+ +/
+
+import std.stdio;
+import chitra;
+
+void main()
+{
+    auto ctx = new Chitra();
+
+    with (ctx)
+    {
+        noStroke;
+
+        fill(0, 0, 255, 0.5);
+        rect(10, 76, 380, 5);
+
+        textFont("American Typewriter", 50);
+        text("Hello World", 10, 10);
+
+        saveAs("output/text.png");
+    }
+}

--- a/source/chitra/elements/formatted_strings.d
+++ b/source/chitra/elements/formatted_strings.d
@@ -55,7 +55,7 @@ struct TextProperties
     TextStretch stretch;
     // Ex: features='dlig=1, -kern, afrc on'
     string features;
-    Nullable!RGBA color;
+    Nullable!RGBA color = RGBA.parse(0);
     Nullable!RGBA background;
     float alpha;
     float backgroundAlpha;


### PR DESCRIPTION
If any element was drawn previously, that fill color was used to draw the text (If no textColor specified). Set the default color to black.