### PR TITLE
Fix image scale when output resolution changes

### DIFF
--- a/examples/tinted_image.d
+++ b/examples/tinted_image.d
@@ -7,21 +7,34 @@ import chitra;
 
 void main()
 {
-    auto ctx = new Chitra(1012, 1013);
+    auto ctx = new Chitra(1518, 1012);
 
     with (ctx)
     {
-        tint("red");
         auto name = "images/tiger.png";
-        image(name, 0, 0);
         auto s = imageSize(name); 
         writefln("W: %s, H: %s", s.width, s.height);
 
+        scale(0.5);
+
         noTint;
-        image(name, 200, 200);
+        image(name, 0, 0);
+
+        tint("red", 0.4);
+        image(name, 1012, 0);
+
+        tint("green", 0.4);
+        image(name, 1012*2, 0);
 
         tint("blue", 0.4);
-        image(name, 400, 400);
+        image(name, 0, 1012);
+
+        tint("brown", 0.4);
+        image(name, 1012, 1012);
+
+        tint("black", 0.4);
+        image(name, 1012*2, 1012);
+
         // Save as png image
         saveAs("output/tinted.png", resolution: 72);
     }

--- a/source/chitra/elements/image.d
+++ b/source/chitra/elements/image.d
@@ -30,6 +30,11 @@ struct Image
         auto w = chitraCtx.correctedSize(w_);
         auto h = chitraCtx.correctedSize(h_);
 
+        auto resolutionScale = chitraCtx.correctedSize(1.0);
+
+        if (resolutionScale != 1)
+            cairo_scale(cairoCtx, resolutionScale, resolutionScale);
+
         // TODO: Scale the image if width and height are given
         auto surface = cairo_image_surface_create_from_png(path.toStringz);
 
@@ -43,8 +48,12 @@ struct Image
             cairo_paint(imgCtx);
         }
 
-        cairo_set_source_surface(cairoCtx, surface, x, y);
+        cairo_set_source_surface(cairoCtx, surface, x/resolutionScale, y/resolutionScale);
         cairo_paint(cairoCtx);
+
+        // Reverse the Resolution scale applied
+        if (resolutionScale != 1)
+            cairo_scale(cairoCtx, 1/resolutionScale, 1/resolutionScale);
     }
 }
 


### PR DESCRIPTION
Image scale was not changed when the canvas resolution changes. For example the following example draws only in 25% of the canvas size because paper size almost increased to 4 times when the default resolution changed to 300 from 72.

```
auto ctx = new Chitra(600);
ctx.image("img_600.png", 0, 0);
ctx.saveAs("output.png", resolution: 300);
```

With this fix the above will render 600px image to full paper width. Works with any resolution setting.