### PR TITLE
feature: `ovalMode` to chose modes for co-ordinates while drawing

### DIFF
--- a/examples/oval_mode.d
+++ b/examples/oval_mode.d
@@ -1,0 +1,90 @@
+/+ dub.sdl:
+dependency "chitra" path="../"
++/
+import std.stdio;
+
+import chitra;
+
+void main()
+{
+    auto ctx = new Chitra(850);
+
+    with (ctx)
+    {
+        background(1);
+
+        fill("#efd49e");
+        ovalMode(CENTER);
+        circle(200, 200, 300);
+
+        ovalMode(RADIUS);
+        circle(600, 200, 150);
+
+        ovalMode(CORNER);
+        circle(50, 450, 300);
+
+        ovalMode(CORNERS);
+        circle(450, 450, 750, 750);
+
+        noStroke;
+        fill(0);
+
+        textFont("American Typewriter", 10);
+        point(200, 200, 6);
+        text("(x, y)", 180, 200);
+        text("ovalMode(CENTER);", 50, 350);
+        text("oval(x, y, w, h);", 50, 370);
+
+        point(600, 200, 6);
+        text("(x, y)", 580, 200);
+        text("ovalMode(RADIUS);", 450, 350);
+        text("oval(x, y, r1, r2);", 450, 370);
+
+        point(50, 450, 6);
+        text("(x, y)", 30, 450);
+        text("ovalMode(CORNER);", 50, 750);
+        text("oval(x, y, w, h);", 50, 770);
+
+        point(450, 450, 6);
+        text("(x, y)", 430, 450);
+        text("(x2, y2)", 750, 750);
+        text("ovalMode(CORNERS);", 450, 750);
+        text("oval(x, y, x2, y2);", 450, 770);
+
+        text("w", 100, 200);
+        text("h", 210, 100);
+        text("w", 100, 600);
+        text("h", 210, 500);
+        text("r1", 700, 200);
+        text("r2", 580, 300);
+
+        strokeWidth(1);
+        stroke("#777777");
+
+        // Width and height lines
+        line(50, 200, 350, 200);
+        line(200, 50, 200, 350);
+
+        // Width and height lines (CORNER)
+        line(50, 600, 350, 600);
+        line(200, 450, 200, 750);
+
+        // Radius lines
+        line(600, 200, 600+150, 200);
+        line(600, 200, 600, 200+150);
+
+        // x, y lines of CORNER
+        line(50, 450, 50, 450+150);
+        line(50, 450, 50+150, 450);
+
+        // x, y lines of CORNERS
+        line(450, 450, 450, 450+150);
+        line(450, 450, 450+150, 450);
+
+        // x2, y2 lines
+        line(750, 750, 750, 750-150);
+        line(750, 750, 750-150, 750);
+        
+        saveAs("output/oval_mode.png");
+    }
+}

--- a/source/chitra/elements/oval.d
+++ b/source/chitra/elements/oval.d
@@ -54,6 +54,27 @@ mixin template ovalFunctions()
     void oval(double x, double y, double w, double h = 0.0)
     {
         h = h == 0.0 ? w : h;
+        switch (this.shapeProps.ovalMode)
+        {
+        case CENTER:
+            x = x - (w / 2.0);
+            y = y - (h / 2.0);
+            break;
+        case RADIUS:
+            x = x - w;
+            y = y - h;
+            w = w * 2.0;
+            h = h * 2.0;
+            break;
+        case CORNER:
+            break;
+        case CORNERS:
+            w = w - x;
+            h = h - y;
+            break;
+        default:
+            break;
+        }
         auto s = Oval(x, y, w, h);
         s.shapeProps = this.shapeProps;
         s.draw(this, this.defaultCairoCtx);
@@ -69,9 +90,9 @@ mixin template ovalFunctions()
        ctx.circle(50, 50, 100);
        ---
      */
-    void circle(double x, double y, double w)
+    void circle(double x, double y, double w, double y2 = 0.0)
     {
-        oval(x, y, w);
+        oval(x, y, w, y2);
     }
 
     /**
@@ -88,8 +109,13 @@ mixin template ovalFunctions()
     void point(double x, double y, int w=1)
     {
         auto prevStrokeWidth = this.shapeProps.strokeWidth;
+        auto prevNoStroke = this.shapeProps.noStroke;
+        auto prevOvalMode = this.shapeProps.ovalMode;
         strokeWidth(0);
+        ovalMode(CENTER);
         oval(x, y, w);
         strokeWidth(prevStrokeWidth);
+        if (prevNoStroke) noStroke;
+        ovalMode(prevOvalMode);
     }
 }

--- a/source/chitra/package.d
+++ b/source/chitra/package.d
@@ -8,6 +8,7 @@ public
     import chitra.helpers;
     import chitra.elements.formatted_strings;
     import chitra.rgba;
+    import chitra.properties : CENTER, RADIUS, CORNER, CORNERS;
 }
 import chitra.context;
 import chitra.properties;

--- a/source/chitra/properties.d
+++ b/source/chitra/properties.d
@@ -9,6 +9,11 @@ import chitra.rgba;
 
 public import chitra.elements.formatted_strings;
 
+enum CENTER = "center";
+enum RADIUS = "radius";
+enum CORNER = "corner";
+enum CORNERS = "corners";
+
 struct ShapeProperties
 {
     RGBA fill = RGBA(0, 0, 0);
@@ -20,6 +25,7 @@ struct ShapeProperties
     //     line_cap = LibCairo::LineCapT::Butt,
     //   line_join = LibCairo::LineJoinT::Miter
     Nullable!RGBA tint = Nullable!RGBA.init;
+    string ovalMode = CENTER;
 }
 
 struct BorderProperties
@@ -275,5 +281,10 @@ mixin template propertiesFunctions()
         import std.typecons : Nullable;
 
         shapeProps.tint = Nullable!RGBA.init;
+    }
+
+    void ovalMode(string value)
+    {
+        shapeProps.ovalMode = value;
     }
 }


### PR DESCRIPTION
oval/circle.

Available modes are `CENTER`, `RADIUS`, `CORNER`, `CORNERS`.

- `CENTER`: First two arguments are center of the oval/circle, next two arguments are width and height (diameter).

```d
ovalMode(CENTER);
oval(x, y, w, h);
```

- `RADIUS`: First two arguments are center of the oval and the next two arguments are horizontal and vertical radius.

```d
ovalMode(RADIUS);
oval(x, y, r1, r2);
```

- `CORNER`: First two arguments are top left corner of the bounding box and next two arguments are width and height (diameter).

```d
ovalMode(CORNER);
oval(x, y, w, h);
```

- `CORNERS`: First two arguments are top left corner of the bounding box. The next two arguments are the coordinates of the bottom right of the bounding box.

```d
ovalMode(CORNERS);
oval(x, y, x2, y2);
```