### PR TITLE
Fix the text color when color is not specified while defining new style

### DIFF
--- a/source/chitra/elements/text.d
+++ b/source/chitra/elements/text.d
@@ -285,6 +285,9 @@ mixin template textFunctions()
     {
         auto ts = TextStyle!Chitra(this, name);
         this.textStyles[name] = TextProperties();
+        if (!shapeProps.noFill)
+            this.textStyles[name].color = shapeProps.fill;
+
         return ts;
     }
 


### PR DESCRIPTION
Text color was set to transparent when a new style is defined. By default set the text color as fill color if `noFill` was not set.