### PR TITLE
Added support for Page and Document variables

### DIFF
--- a/examples/pdf_pages.d
+++ b/examples/pdf_pages.d
@@ -1,0 +1,64 @@
+/+ dub.sdl:
+ dependency "chitra" path="../"
+ +/
+
+import std.stdio;
+import std.datetime.systime : Clock, SysTime;
+import std.format : format;
+
+import chitra;
+
+string dateTimeNow()
+{
+    SysTime now = Clock.currTime();
+
+    // 2. Format as YYYY-MM-DD HH:MM:SS
+    return format("%04d-%02d-%02d %02d:%02d:%02d",
+                  now.year, cast(int)now.month, now.day,
+                  now.hour, now.minute, now.second);
+}
+
+void addFooter(Chitra ctx)
+{
+    with(ctx)
+    {
+        saveState;
+        font("IBM Plex Mono", 12);
+        textAlign(CENTER);
+        text("{{ currentPage }} / {{ totalPages }}", 0, height - 50, width, 50);
+        textAlign(RIGHT);
+        font("American Typewriter", 10);
+        text("{{ chapterName }}", 50, height - 50, width - 100, 50);
+        restoreState;
+    }
+}
+
+void main()
+{
+    auto ctx = new Chitra();
+
+    with (ctx)
+    {
+        noStroke;
+        font("Inter", 14);
+
+        setVariable("date", dateTimeNow);
+
+        setVariable("chapterName", "Chapter 1");
+        rect(100, 100, 200);
+        addFooter(ctx);
+
+        newPage;
+        rect(100, 100, 200);
+        addFooter(ctx);
+
+        newPage;
+        setVariable("chapterName", "Chapter 2");
+        addFooter(ctx);
+
+        fill(100);
+        text("Last updated on {{ date }}", 100, 500);
+
+        saveAs("output/multipage.pdf");
+    }
+}

--- a/source/chitra/context.d
+++ b/source/chitra/context.d
@@ -49,6 +49,8 @@ class Context
     string overflowMarkup_;
     SavedStateContext[] savedStateContexts;
     Path lastPath_;
+    string[string] documentVars;
+    string[string] pageVars;
 
     @property double width() const
     {
@@ -94,6 +96,10 @@ class Context
         // is this nested struct initialize issue or colors lib issue? Not sure.
         shapeProps.fill = RGBA(0, 0, 0);
         shapeProps.stroke = RGBA(0, 0, 0);
+
+        // Initialize the default values
+        setPageVariable("currentPage", 1);
+        setDocumentVariable("totalPages", 1);
     }
 
     this(double width = defaultWidth, double height = 0)
@@ -201,5 +207,20 @@ class Context
         defaultCairoCtx = cairo_create(this.defaultSurface);
         shapeProps = ShapeProperties.init;
         textProps = TextProperties.init;
+    }
+
+    void setPageVariable(T)(string key, T value)
+    {
+        this.pageVars[key] = value.to!string;
+    }
+
+    void setDocumentVariable(T)(string key, T value)
+    {
+        this.documentVars[key] = value.to!string;
+    }
+
+    void setVariable(T)(string key, T value)
+    {
+        setPageVariable(key, value);
     }
 }

--- a/source/chitra/elements/new_page.d
+++ b/source/chitra/elements/new_page.d
@@ -1,5 +1,7 @@
 module chitra.elements.new_page;
 
+import std.conv : to;
+
 import chitra.context;
 import chitra.elements.core;
 
@@ -24,6 +26,8 @@ mixin template newPageFunctions()
     {
         NewPage s;
         s.draw(this, this.defaultCairoCtx);
+        setPageVariable("currentPage", this.pageVars["currentPage"].to!int + 1);
+        setDocumentVariable("totalPages", this.documentVars["totalPages"].to!int + 1);
         this.elements ~= Element(s);
     }
 }

--- a/source/chitra/elements/text.d
+++ b/source/chitra/elements/text.d
@@ -10,7 +10,7 @@ import chitra.elements.core;
 import chitra.elements.formatted_strings;
 import chitra.rgba;
 import chitra.elements.markup_tokens;
-import chitra.helpers : Size, Box;
+import chitra.helpers : Size, Box, variableSubstitution;
 
 struct Text
 {
@@ -109,6 +109,7 @@ struct Text
             pango_layout_set_height(layout, cast(int)h * PANGO_SCALE);
 
         auto fullMarkup = txt.content(chitraCtx);
+        fullMarkup = variableSubstitution(fullMarkup, chitraCtx.documentVars);
 
         if (textProps.hyphenation)
             pango_layout_set_wrap(layout, PANGO_WRAP_CHAR);
@@ -189,6 +190,8 @@ mixin template textFunctions()
     string applyTextStyles(string txt)
     {
         import std.array;
+
+        txt = variableSubstitution(txt, this.pageVars, onMissingKey: MissingKey.passThrough);
 
         if (this.textProps.syntaxHighlight)
             txt = prepareForCodeHighlight(txt, this.textProps.syntaxHighlightTheme);

--- a/source/chitra/helpers.d
+++ b/source/chitra/helpers.d
@@ -4,6 +4,8 @@ import std.typecons;
 import std.math : isNaN;
 import std.algorithm : min, max;
 import std.math.constants : PI;
+import std.array : appender;
+import std.string : indexOf, strip;
 
 import chitra.rgba;
 
@@ -368,4 +370,69 @@ double degrees(T)(T angle)
 double radians(T)(T angle)
 {
     return angle;
+}
+
+enum MissingKey
+{
+    empty,
+    passThrough,
+    error
+}
+
+string variableSubstitution(string txt, string[string] data, MissingKey onMissingKey = MissingKey.init)
+{
+    auto result = appender!string();
+    size_t pos = 0;
+
+    while (pos < txt.length)
+    {
+        // Find the next variable
+        auto openIdx = txt.indexOf("{{", pos);
+        if (openIdx == -1)
+        {
+            // No more variables found, copy the remaining text as-is
+            result.put(txt[pos .. $]);
+            break;
+        }
+
+        // Text before the variable
+        result.put(txt[pos .. openIdx]);
+
+        // Closing "}}"
+        auto closeIdx = txt.indexOf("}}", openIdx + 2);
+        if (closeIdx == -1)
+        {
+            // Variable not closed, get the rest
+            // of the string and stop searching.
+            result.put(txt[openIdx .. $]);
+            break;
+        }
+
+        immutable rawName = txt[openIdx + 2 .. closeIdx];
+        immutable varName = strip(rawName);
+
+        // Known variable, substitute its value
+        if (auto val = varName in data)
+            result.put(*val);
+        else
+        {
+            // Handle Unknown variable
+            switch (onMissingKey)
+            {
+            case MissingKey.passThrough:
+                result.put(txt[openIdx .. closeIdx + 2]);
+                break;
+            case MissingKey.error:
+                throw new Exception(varName ~ " not found in data");
+                break;
+            default:
+                result.put("");
+                break;
+            }
+        }
+
+        pos = closeIdx + 2;
+    }
+
+    return result.data;
 }


### PR DESCRIPTION
- Page variables - Variable related to a page, for example `currentPage`, `chapterName` etc.
- Document variables - Variable related to the full document. Like `totalPages`.

Add a new variable or page variable using

```
ctx.setPageVariable(varName, varValue);
ctx.setVariable(varName, varValue); // Same as above
```

Add a new document variable,

```d
ctx.setDocumentVariable(varName, varValue);
```

The main difference between page and document variables is that the page variable will be set while preparing the text itself. The document variable is set before the final rendering (saveAs command).

By default, Chitra provides a few variables:

- `totalPages` - Useful when multi page PDF is generated (Document variable).
- `currentPage` - Current page number (page variable).